### PR TITLE
Added version numbers for dependencies in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 authors = ["rvr"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-roxmltree = ""
-xmlparser = ""
-byteorder = ""
+roxmltree = "0.7.1"
+xmlparser = "0.10.0"
+byteorder = "1.3.2"


### PR DESCRIPTION
It's a better practice to have numbered versions of the dependencies, since it will only allow updates of compatible versions of them, and will be easier to maintain with tools such as `cargo-edit`.