### PR TITLE
Some code improvements

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,6 +1,5 @@
+use byteorder::{LittleEndian, ReadBytesExt};
 use std::io::Cursor;
-use byteorder::LittleEndian;
-use byteorder::ReadBytesExt;
 
 #[allow(dead_code)]
 pub fn u8_to_i8(vector: &[u8]) -> Vec<i8> {
@@ -73,8 +72,8 @@ t_to_u8_be!(i64_to_v_u8_be, i64);
 t_to_u8_be!(i128_to_v_u8_be, i128);
 t_to_u8_be!(u128_to_v_u8_be, u128);
 
-// From u16 to i16 to Vec<u8> (Big Endian)
-#[allow(dead_code)]
+/// From u16 to i16 to Vec<u8> (Big Endian)
+#[allow(clippy::cast_possible_wrap)]
 pub fn u16_to_i16_to_v_u8_be(v: &[u16]) -> Vec<u8> {
     let mut result: Vec<u8> = Vec::new();
     for integer in v {
@@ -88,8 +87,8 @@ pub fn u16_to_i16_to_v_u8_be(v: &[u16]) -> Vec<u8> {
     result
 }
 
-// From u32 to i32 to Vec<u8> (Big Endian)
-#[allow(dead_code)]
+/// From u32 to i32 to Vec<u8> (Big Endian)
+#[allow(clippy::cast_possible_wrap)]
 pub fn u32_to_i32_to_v_u8_be(v: &[u32]) -> Vec<u8> {
     let mut result: Vec<u8> = Vec::new();
     for integer in v {
@@ -103,8 +102,7 @@ pub fn u32_to_i32_to_v_u8_be(v: &[u32]) -> Vec<u8> {
     result
 }
 
-// From f32 to Vec<u8> (Big Endian)
-#[allow(dead_code)]
+/// From f32 to Vec<u8> (Big Endian)
 pub fn f32_to_v_u8_be(v: &[f32]) -> Vec<u8> {
     let mut result: Vec<u8> = Vec::new();
     for float in v {
@@ -114,8 +112,7 @@ pub fn f32_to_v_u8_be(v: &[f32]) -> Vec<u8> {
     result
 }
 
-// From f64 to Vec<u8> (Big Endian)
-#[allow(dead_code)]
+/// From f64 to Vec<u8> (Big Endian)
 pub fn f64_to_v_u8_be(v: &[f64]) -> Vec<u8> {
     let mut result: Vec<u8> = Vec::new();
     for float in v {

--- a/src/fitswriter.rs
+++ b/src/fitswriter.rs
@@ -1,6 +1,7 @@
-use std::fs::File;
-use std::io;
-use std::io::Write;
+use std::{
+    fs::File,
+    io::{self, Write},
+};
 
 pub struct FitsHeaderData {
     pub bitpix: i64,
@@ -17,8 +18,8 @@ pub struct FitsHeaderData {
 
 // Struct to store FITS keywords
 pub struct FITSKeyword {
-    pub name:    String,
-    pub value:   String,
+    pub name: String,
+    pub value: String,
     pub comment: String,
 }
 
@@ -33,22 +34,45 @@ fn fits_write_header(fits: &mut File, string: &str, bytes: &mut u64) -> io::Resu
     Ok(())
 }
 
-fn fits_write_header_u64(fits: &mut File, header: &str, value: u64, comment: &str, bytes: &mut u64) -> io::Result<()> {
+fn fits_write_header_u64(
+    fits: &mut File,
+    header: &str,
+    value: u64,
+    comment: &str,
+    bytes: &mut u64,
+) -> io::Result<()> {
     let string = format!("{:8} = {:<19} / {:47}", header, value, comment);
     fits_write_header(fits, &string, bytes)
 }
 
-fn fits_write_header_i64(fits: &mut File, header: &str, value: i64, comment: &str, bytes: &mut u64) -> io::Result<()> {
+fn fits_write_header_i64(
+    fits: &mut File,
+    header: &str,
+    value: i64,
+    comment: &str,
+    bytes: &mut u64,
+) -> io::Result<()> {
     let string = format!("{:8} = {:<19} / {:47}", header, value, comment);
     fits_write_header(fits, &string, bytes)
 }
 
-fn fits_write_header_string(fits: &mut File, header: &str, value: &str, comment: &str, bytes: &mut u64) -> io::Result<()> {
+fn fits_write_header_string(
+    fits: &mut File,
+    header: &str,
+    value: &str,
+    comment: &str,
+    bytes: &mut u64,
+) -> io::Result<()> {
     let string = format!("{:8} = {:<19} / {:48}", header, value, comment);
     fits_write_header(fits, &string, bytes)
 }
 
-fn fits_write_header_comment(fits: &mut File, header: &str, comment: &str, bytes: &mut u64) -> io::Result<()> {
+fn fits_write_header_comment(
+    fits: &mut File,
+    header: &str,
+    comment: &str,
+    bytes: &mut u64,
+) -> io::Result<()> {
     let string = format!("{:8}{:72}", header, comment);
     fits_write_header(fits, &string, bytes)
 }
@@ -60,9 +84,9 @@ fn fits_write_header_no_comment(fits: &mut File, header: &str, bytes: &mut u64) 
 
 fn fits_write_image_data(fits: &mut File, fits_hd: &FitsHeaderData, bytes: u64) -> io::Result<()> {
     // Write HDU (fill the rest of the 2880 byte-block)
-    let rest = bytes % 2880;
-    if rest > 0 {
-        let rest = 2880 - rest;
+    let hdu_rest = bytes % 2880;
+    if hdu_rest > 0 {
+        let rest = 2880 - hdu_rest;
         for _i in 0..rest {
             fits.write_all(b" ")?;
         }
@@ -72,11 +96,11 @@ fn fits_write_image_data(fits: &mut File, fits_hd: &FitsHeaderData, bytes: u64) 
     println!("FITS write > Write image data");
     fits.write_all(&fits_hd.data_bytes)?;
     let total = fits_hd.data_bytes.len() as u64;
-    let rest = total % 2880;
+    let data_unit_rest = total % 2880;
     println!("FITS write > Write image data > Bytes total: {}", total);
     // Write Data Unit (fill the rest of the 2880 byte-block)
-    if rest > 0 {
-        let rest = 2880 - rest;
+    if data_unit_rest > 0 {
+        let rest = 2880 - data_unit_rest;
         for _i in 0..rest {
             fits.write_all(&[0])?;
         }
@@ -96,8 +120,14 @@ pub fn fits_write_data(filename: &str, fits_hd: &FitsHeaderData) -> io::Result<(
     fits_write_header_i64(&mut fits, "BITPIX", fits_hd.bitpix, "", &mut bytes)?;
     fits_write_header_u64(&mut fits, "NAXIS", fits_hd.naxis, "", &mut bytes)?;
     for i in 0..fits_hd.naxis_vec.len() {
-        let header_name = format!("NAXIS{}", i+1);
-        fits_write_header_u64(&mut fits, &header_name, fits_hd.naxis_vec[i], "", &mut bytes)?;
+        let header_name = format!("NAXIS{}", i + 1);
+        fits_write_header_u64(
+            &mut fits,
+            &header_name,
+            fits_hd.naxis_vec[i],
+            "",
+            &mut bytes,
+        )?;
     }
     fits_write_header_string(&mut fits, "EXTEND", "T", "", &mut bytes)?;
     fits_write_header_string(&mut fits, "BZERO", "0", "", &mut bytes)?;
@@ -122,7 +152,11 @@ pub fn fits_write_data(filename: &str, fits_hd: &FitsHeaderData) -> io::Result<(
 }
 
 // Write FITS data, but use FITS keywords for the header
-pub fn fits_write_data_keywords(filename: &str, fits_hd: &FitsHeaderData, fits_keywords: &[FITSKeyword]) -> io::Result<()> {
+pub fn fits_write_data_keywords(
+    filename: &str,
+    fits_hd: &FitsHeaderData,
+    fits_keywords: &[FITSKeyword],
+) -> io::Result<()> {
     println!("FITS write > File name > {}", filename);
     let mut fits = File::create(filename)?;
     let mut bytes = 0;
@@ -133,7 +167,13 @@ pub fn fits_write_data_keywords(filename: &str, fits_hd: &FitsHeaderData, fits_k
         if keyword.name == "HISTORY" || keyword.name == "COMMENT" {
             fits_write_header_comment(&mut fits, &keyword.name, &keyword.comment, &mut bytes)?;
         } else {
-            fits_write_header_string(&mut fits, &keyword.name, &keyword.value, &keyword.comment, &mut bytes)?;
+            fits_write_header_string(
+                &mut fits,
+                &keyword.name,
+                &keyword.value,
+                &keyword.comment,
+                &mut bytes,
+            )?;
         }
     }
     fits_write_header_no_comment(&mut fits, "END", &mut bytes)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,35 @@
-extern crate roxmltree;
+//! XISFITS is a command line tool to convert XISF images to FITS.
+
+#![forbid(anonymous_parameters)]
+#![warn(clippy::pedantic)]
+#![deny(
+    clippy::all,
+    variant_size_differences,
+    unused_results,
+    unused_qualifications,
+    unused_import_braces,
+    unsafe_code,
+    trivial_numeric_casts,
+    trivial_casts,
+    missing_docs,
+    unused_extern_crates,
+    missing_debug_implementations,
+    missing_copy_implementations
+)]
 
 mod convert;
 mod fitswriter;
 
-use std::io;
-use std::io::Read;
-use std::io::Seek;
-use std::io::SeekFrom;
-use std::fs::File;
-use std::env;
-use std::process;
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    env,
+    fs::File,
+    io::{self, Read, Seek, SeekFrom},
+    process,
+};
 
 // Struct to store XISF header data
+#[derive(Debug, Default)]
 struct XISFHeader {
     signature: String,
     length: u32,
@@ -32,13 +49,14 @@ struct XISFHeader {
 }
 
 // Struct to store image data as vector
+#[derive(Debug, Default)]
 struct XISFData {
     // int8:    Vec<Vec<i8>>,
-    uint8:   Vec<Vec<u8>>,
+    uint8: Vec<Vec<u8>>,
     // int16:   Vec<Vec<i16>>,
-    uint16:  Vec<Vec<u16>>,
+    uint16: Vec<Vec<u16>>,
     // int32:   Vec<Vec<i32>>,
-    uint32:  Vec<Vec<u32>>,
+    uint32: Vec<Vec<u32>>,
     // int64:   Vec<Vec<i64>>,
     // uint64:  Vec<Vec<u64>>,
     // int128:  Vec<Vec<i128>>,
@@ -47,59 +65,32 @@ struct XISFData {
     float64: Vec<Vec<f64>>,
 }
 
+#[allow(clippy::cognitive_complexity)]
 fn main() -> io::Result<()> {
     // Define variables
-    let mut xisf_header = XISFHeader {
-        signature: String::from(""),
-        length: 0,
-        reserved: 0,
-        header: String::from(""),
-        geometry: String::from(""),
-        geometry_channels: 0,
-        geometry_sizes: vec![],
-        geometry_channel_size: 0,
-        sample_format: String::from(""),
-        sample_format_bytes: 0,
-        color_space: String::from(""),
-        location: String::from(""),
-        location_method: String::from(""),
-        location_start: 0,
-        location_length: 0,
-    };
-
-    let mut xisf_data = XISFData {
-        // format:  String::from(""),
-        // int8:    vec![],
-        uint8:   vec![],
-        // int16:   vec![],
-        uint16:  vec![],
-        // int32:   vec![],
-        uint32:  vec![],
-        // int64:   vec![],
-        // uint64:  vec![],
-        // int128:  vec![],
-        // uint128: vec![],
-        float32: vec![],
-        float64: vec![],
-    };
+    let mut xisf_header = XISFHeader::default();
+    let mut xisf_data = XISFData::default();
 
     // Fundamental Scalar Types
-    let xisf_type_size: HashMap<&str, u8> =
-        [("Int8", 1),
-         ("UInt8", 1),
-         ("Int16", 2),
-         ("UInt16", 2),
-         ("Int32", 4),
-         ("UInt32", 4),
-         ("Int32", 4),
-         ("Int64", 8),
-         ("UInt64", 8),
-         ("Int128", 16),
-         ("UInt128", 16),
-         ("Float32", 4),
-         ("Float64", 8),
-         ("Float128", 16),
-        ].iter().cloned().collect();
+    let xisf_type_size: HashMap<&str, u8> = [
+        ("Int8", 1),
+        ("UInt8", 1),
+        ("Int16", 2),
+        ("UInt16", 2),
+        ("Int32", 4),
+        ("UInt32", 4),
+        ("Int32", 4),
+        ("Int64", 8),
+        ("UInt64", 8),
+        ("Int128", 16),
+        ("UInt128", 16),
+        ("Float32", 4),
+        ("Float64", 8),
+        ("Float128", 16),
+    ]
+    .iter()
+    .cloned()
+    .collect();
 
     let mut xisf_fits_keywords = Vec::new();
 
@@ -115,7 +106,6 @@ fn main() -> io::Result<()> {
         process::exit(1);
     }
     println!("Args: {:?}", args);
- 
     // Open XISF image file
     let xisf_filename = &args[1];
     let fits_filename = &args[2];
@@ -125,15 +115,20 @@ fn main() -> io::Result<()> {
 
     // -- Read header fields
     // Header: Signature
-    f.by_ref().take(8).read_to_string(&mut buffer_header_signature)?;
+    let _ = f
+        .by_ref()
+        .take(8)
+        .read_to_string(&mut buffer_header_signature)?;
     // Header: Length of XML section
     f.read_exact(&mut buffer_header_length)?;
     // Header: Reserved for future use
     f.read_exact(&mut buffer_header_reserved)?;
 
     // Header: XML section
-    let mut handle = f.by_ref().take(u64::from(convert::u8_to_v_u32(&buffer_header_length)[0]));
-    handle.read_to_string(&mut buffer_header_header)?;
+    let mut handle = f
+        .by_ref()
+        .take(u64::from(convert::u8_to_v_u32(&buffer_header_length)[0]));
+    let _ = handle.read_to_string(&mut buffer_header_header)?;
 
     // Assign header values to XISF header struct
     xisf_header.signature = buffer_header_signature.clone();
@@ -159,7 +154,7 @@ fn main() -> io::Result<()> {
         Err(e) => {
             println!("Error: {}.", e);
             process::exit(1);
-        },
+        }
     };
 
     for node in doc.descendants() {
@@ -168,14 +163,19 @@ fn main() -> io::Result<()> {
             if node.tag_name().name() == "Image" {
                 // Parse and store <Image> tag attributes
                 for attr in node.attributes() {
-                    println!("<{} {}=\"{}\">", node.tag_name().name(), attr.name(), attr.value());
+                    println!(
+                        "<{} {}=\"{}\">",
+                        node.tag_name().name(),
+                        attr.name(),
+                        attr.value()
+                    );
                     if attr.name() == "geometry" {
                         xisf_header.geometry = attr.value().to_string();
                         // Parse geometry string (size_x:size_y:n)
                         let geometry_data: Vec<&str> = xisf_header.geometry.split(':').collect();
                         if geometry_data.len() > 1 {
                             let mut channel_size = 0;
-                            for g_data in geometry_data.iter() {
+                            for g_data in &geometry_data {
                                 let size = g_data.parse::<u64>().unwrap();
                                 if channel_size == 0 {
                                     channel_size = size;
@@ -185,12 +185,15 @@ fn main() -> io::Result<()> {
                                 xisf_header.geometry_sizes.push(size);
                             }
                             xisf_header.geometry_channel_size = channel_size;
-                            xisf_header.geometry_channels = geometry_data[geometry_data.len() - 1].parse::<u64>().unwrap();
+                            xisf_header.geometry_channels = geometry_data[geometry_data.len() - 1]
+                                .parse::<u64>()
+                                .unwrap();
                         }
                     } else if attr.name() == "sampleFormat" {
                         // Parse image format
                         xisf_header.sample_format = attr.value().to_string();
-                        xisf_header.sample_format_bytes = xisf_type_size[xisf_header.sample_format.as_str()];
+                        xisf_header.sample_format_bytes =
+                            xisf_type_size[xisf_header.sample_format.as_str()];
                     } else if attr.name() == "colorSpace" {
                         // Parse space color
                         xisf_header.color_space = attr.value().to_string();
@@ -198,7 +201,7 @@ fn main() -> io::Result<()> {
                         // Parse location. Format: "chan_size1:..:chan_size_n:n_channels" format
                         xisf_header.location = attr.value().to_string();
                         let split = xisf_header.location.split(':');
-                        for (n,s) in split.enumerate() {
+                        for (n, s) in split.enumerate() {
                             println!("Location part: {}", s);
                             if n == 0 {
                                 xisf_header.location_method = s.to_string();
@@ -210,7 +213,7 @@ fn main() -> io::Result<()> {
                         }
                     }
                 }
-                // NOTE: location_length == geometry x * geometry y * ... * geometry n.
+            // NOTE: location_length == geometry x * geometry y * ... * geometry n.
             } else if node.tag_name().name() == "FITSKeyword" {
                 // Parse and store the values of the FITS keyword
                 let mut xisf_fits_keyword = fitswriter::FITSKeyword {
@@ -227,12 +230,15 @@ fn main() -> io::Result<()> {
                         xisf_fits_keyword.comment = attr.value().to_string();
                     }
                 }
-                println!("FITS Keyword: {} = {} / {}", xisf_fits_keyword.name, xisf_fits_keyword.value, xisf_fits_keyword.comment);
+                println!(
+                    "FITS Keyword: {} = {} / {}",
+                    xisf_fits_keyword.name, xisf_fits_keyword.value, xisf_fits_keyword.comment
+                );
                 xisf_fits_keywords.push(xisf_fits_keyword);
             }
         }
     }
-    // Calculate the size in bytes of the image 
+    // Calculate the size in bytes of the image
     if xisf_header.sample_format_bytes > 0 {
         xisf_header.geometry_channel_size *= u64::from(xisf_header.sample_format_bytes);
     }
@@ -242,7 +248,10 @@ fn main() -> io::Result<()> {
     println!("Geometry: {}", xisf_header.geometry);
     println!("Geometry sizes: {:?}", xisf_header.geometry_sizes);
     println!("Geometry channels: {}", xisf_header.geometry_channels);
-    println!("Geometry channel size: {}", xisf_header.geometry_channel_size);
+    println!(
+        "Geometry channel size: {}",
+        xisf_header.geometry_channel_size
+    );
     println!("Sample format: {}", xisf_header.sample_format);
     println!("Sample format: {}", xisf_header.sample_format_bytes);
     println!("Color space: {}", xisf_header.color_space);
@@ -250,35 +259,47 @@ fn main() -> io::Result<()> {
     println!("Location method: {}", xisf_header.location_method);
     println!("Location start: {}", xisf_header.location_start);
     println!("Location length: {}", xisf_header.location_length);
-    println!("Location length ({}) == channel size * channels ({})", xisf_header.location_length, xisf_header.geometry_channel_size * xisf_header.geometry_channels);
+    println!(
+        "Location length ({}) == channel size * channels ({})",
+        xisf_header.location_length,
+        xisf_header.geometry_channel_size * xisf_header.geometry_channels
+    );
 
     // -- Read image data from file
     // Interpret it as numbers and store as vector/s
     if xisf_header.location_method == "attachment" && 
         // Goto to file position where the image begins
-        xisf_header.location_start + xisf_header.location_length <= file_size {
+        xisf_header.location_start + xisf_header.location_length <= file_size
+    {
         match f.seek(SeekFrom::Start(xisf_header.location_start)) {
             Ok(v) => println!("Read XISF > File correctly seek: {:?}", v),
-            Err(r) => println!("Read XISF > Error seeking file: {:?}", r)
+            Err(r) => println!("Read XISF > Error seeking file: {:?}", r),
         }
 
         // Read each channel
         for n in 0..xisf_header.geometry_channels {
             let mut image_channel = Vec::new();
             // Read channel size bytes
-            match f.by_ref().take(xisf_header.geometry_channel_size).read_to_end(&mut image_channel) {
+            match f
+                .by_ref()
+                .take(xisf_header.geometry_channel_size)
+                .read_to_end(&mut image_channel)
+            {
                 Ok(v) => println!("Read XISF > Data correctly read (channel {}): {:?}", n, v),
-                Err(r) => println!("Read XISF > Error reading image (channel {}): {:?}", n, r)
+                Err(r) => println!("Read XISF > Error reading image (channel {}): {:?}", n, r),
             };
 
             // Convert bytes to actual numbers and store the channel in a vector
-            match xisf_header.sample_format.as_str() {                
+            match xisf_header.sample_format.as_str() {
                 "UInt8" => xisf_data.uint8.push(image_channel.clone()),
                 "UInt16" => xisf_data.uint16.push(convert::u8_to_v_u16(&image_channel)),
                 "UInt32" => xisf_data.uint32.push(convert::u8_to_v_u32(&image_channel)),
                 "Float32" => xisf_data.float32.push(convert::u8_to_v_f32(&image_channel)),
                 "Float64" => xisf_data.float64.push(convert::u8_to_v_f64(&image_channel)),
-                 _ => println!("Read XISF > Unsupported type > {}", xisf_header.sample_format.as_str()),
+                _ => println!(
+                    "Read XISF > Unsupported type > {}",
+                    xisf_header.sample_format.as_str()
+                ),
             }
 
             // Show the first 20 bytes of the original image data
@@ -294,8 +315,8 @@ fn main() -> io::Result<()> {
 
     // -- Convert XISF to FITS
     println!("Convert to FITS > Image data to bytes");
-    let mut data_bytes: Vec<u8> = vec![];
-    let mut bitpix: i64 = 0;
+    let mut data_bytes = vec![];
+    let mut bitpix = 0_i64;
     // Convert binary formats
     //
     // +---------+-------+------+
@@ -309,29 +330,32 @@ fn main() -> io::Result<()> {
     // +---------+-------+------+
     //
     for i in 0..xisf_header.geometry_channels as usize {
-            match xisf_header.sample_format.as_str() {
-                "UInt8" => {
-                    bitpix = 8;
-                    data_bytes.append(&mut xisf_data.uint8[i]);
-                },
-                "UInt16" => {
-                    bitpix = 16;
-                    data_bytes.append(&mut convert::u16_to_i16_to_v_u8_be(&xisf_data.uint16[i]));
-                },
-                "UInt32" => {
-                    bitpix = 32;
-                    data_bytes.append(&mut convert::u32_to_i32_to_v_u8_be(&xisf_data.uint32[i]));
-                },
-                "Float32" =>  {
-                    bitpix = -32;
-                    data_bytes.append(&mut convert::f32_to_v_u8_be(&xisf_data.float32[i]));
-                },
-                "Float64" =>  {
-                    bitpix = -64;
-                    data_bytes.append(&mut convert::f64_to_v_u8_be(&xisf_data.float64[i]));
-                },
-                 _ => println!("Convert to FITS > Unsupported XISF type > {}", xisf_header.sample_format.as_str()),
+        match xisf_header.sample_format.as_str() {
+            "UInt8" => {
+                bitpix = 8;
+                data_bytes.append(&mut xisf_data.uint8[i]);
             }
+            "UInt16" => {
+                bitpix = 16;
+                data_bytes.append(&mut convert::u16_to_i16_to_v_u8_be(&xisf_data.uint16[i]));
+            }
+            "UInt32" => {
+                bitpix = 32;
+                data_bytes.append(&mut convert::u32_to_i32_to_v_u8_be(&xisf_data.uint32[i]));
+            }
+            "Float32" => {
+                bitpix = -32;
+                data_bytes.append(&mut convert::f32_to_v_u8_be(&xisf_data.float32[i]));
+            }
+            "Float64" => {
+                bitpix = -64;
+                data_bytes.append(&mut convert::f64_to_v_u8_be(&xisf_data.float64[i]));
+            }
+            _ => println!(
+                "Convert to FITS > Unsupported XISF type > {}",
+                xisf_header.sample_format.as_str()
+            ),
+        }
     }
 
     // Show the first 20 bytes of the converted image
@@ -357,10 +381,10 @@ fn main() -> io::Result<()> {
             comment: vec![String::from("")],
             data_bytes,
         };
-        if !xisf_fits_keywords.is_empty() {
-            fitswriter::fits_write_data_keywords(fits_filename, &fits_hd, &xisf_fits_keywords)?;
-        } else {
+        if xisf_fits_keywords.is_empty() {
             fitswriter::fits_write_data(fits_filename, &fits_hd)?;
+        } else {
+            fitswriter::fits_write_data_keywords(fits_filename, &fits_hd, &xisf_fits_keywords)?;
         }
     }
     // -- End of convert XISF to FITS


### PR DESCRIPTION
I ran `cargo clippy` and found out a couple of things to improve. I also ran `cargo fmt` to adapt the code formatting to Rust standards, and derived `Debug` and `Default` for the two main data structures (`XISFHeader` and `XISFData`). This allows a cleaner initialization, only calling `default()`, and in case of needing to debug them, it's easy to just call `dbg!()` on them.