### PR TITLE
Added build profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,26 @@ edition = "2018"
 roxmltree = ""
 xmlparser = ""
 byteorder = ""
+
+# The release profile, used for `cargo build`.
+[profile.dev]
+incremental = true
+opt-level = 1
+debug = true
+rpath = false
+lto = false
+debug-assertions = true
+overflow-checks = true
+panic = 'unwind'
+
+# The release profile, used for `cargo build --release`.
+[profile.release]
+incremental = false
+opt-level = 3
+debug = false
+rpath = false
+codegen-units = 1
+lto = true
+debug-assertions = false
+overflow-checks = false
+panic = 'unwind'


### PR DESCRIPTION
This should enable fine grain configuration of build profiles. Adds LTO to release builds, for higher performance, and ensures no debug assertions or overflow checks. On the other hand, the development profile will be fast to build and will include some minor optimizations.