### PR TITLE
Added even more optimizations

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -21,7 +21,7 @@ macro_rules! u8_to_t {
         #[allow(dead_code)]
         pub fn $func_name(vector: &[u8]) -> Vec<$type> {
             let mut rdr = Cursor::new(vector);
-            let mut values = Vec::new();
+            let mut values = Vec::with_capacity(vector.len() / std::mem::size_of::<$type>());
 
             loop {
                 let option = rdr.$read_func::<LittleEndian>();

--- a/src/fitswriter.rs
+++ b/src/fitswriter.rs
@@ -8,7 +8,7 @@ use std::{
 pub struct FitsHeaderData<'h> {
     pub bitpix: i64,
     pub naxis: u64,
-    pub naxis_vec: &'h [u64],
+    pub naxis_vec: &'h [usize],
     pub bzero: u64,
     pub bscale: u64,
     pub datamin: u64,
@@ -139,7 +139,7 @@ pub fn fits_write_data(filename: &Path, fits_hd: &FitsHeaderData) -> io::Result<
         fits_write_header_u64(
             &mut fits,
             &header_name,
-            fits_hd.naxis_vec[i],
+            fits_hd.naxis_vec[i] as u64,
             "",
             &mut bytes,
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,7 @@ fn main() -> io::Result<()> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::xisfreader::XISFSampleFormat;
 
     fn init() {
         let _ = env_logger::builder().is_test(true).try_init();
@@ -178,7 +179,7 @@ mod test {
         match xisf_file {
             Ok(file) => {
                 assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt8);
-                assert_eq!(file.header().geometry(), "256:256:1");
+                assert_eq!(file.header().geometry().to_string(), "256:256:1");
             }
             Err(e) => {
                 eprintln!("Tests > Error: {}", e);
@@ -197,7 +198,7 @@ mod test {
         match xisf_file {
             Ok(file) => {
                 assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt16);
-                assert_eq!(file.header().geometry(), "256:256:3");
+                assert_eq!(file.header().geometry().to_string(), "256:256:3");
             }
             Err(e) => {
                 eprintln!("Tests > Error: {}", e);
@@ -216,7 +217,7 @@ mod test {
         match xisf_file {
             Ok(file) => {
                 assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt32);
-                assert_eq!(file.header().geometry(), "256:256:3");
+                assert_eq!(file.header().geometry().to_string(), "256:256:3");
             }
             Err(e) => {
                 eprintln!("Tests > Error: {}", e);
@@ -236,7 +237,7 @@ mod test {
         match xisf_file {
             Ok(file) => {
                 assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt8);
-                assert_eq!(file.header().geometry(), "256:256:3");
+                assert_eq!(file.header().geometry().to_string(), "256:256:3");
             }
             Err(e) => {
                 eprintln!("Tests > Error: {}", e);
@@ -256,7 +257,7 @@ mod test {
         match xisf_file {
             Ok(file) => {
                 assert_eq!(file.header().sample_format(), XISFSampleFormat::Float32);
-                assert_eq!(file.header().geometry(), "255:255:1");
+                assert_eq!(file.header().geometry().to_string(), "255:255:1");
             }
             Err(e) => {
                 eprintln!("Tests > Error: {}", e);
@@ -276,7 +277,7 @@ mod test {
         match xisf_file {
             Ok(file) => {
                 assert_eq!(file.header().sample_format(), XISFSampleFormat::Float64);
-                assert_eq!(file.header().geometry(), "255:255:1");
+                assert_eq!(file.header().geometry().to_string(), "255:255:1");
             }
             Err(e) => {
                 eprintln!("Tests > Error: {}", e);
@@ -296,7 +297,7 @@ mod test {
         match xisf_file {
             Ok(file) => {
                 assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt16);
-                assert_eq!(file.header().geometry(), "256:256:1");
+                assert_eq!(file.header().geometry().to_string(), "256:256:1");
                 assert_eq!(file.header().compression_codec(), "zlib");
             }
             Err(e) => {
@@ -317,7 +318,7 @@ mod test {
         match xisf_file {
             Ok(file) => {
                 assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt16);
-                assert_eq!(file.header().geometry(), "256:256:1");
+                assert_eq!(file.header().geometry().to_string(), "256:256:1");
                 assert_eq!(file.header().compression_codec(), "zlib+sh");
             }
             Err(e) => {
@@ -339,7 +340,7 @@ mod test {
         match xisf_file {
             Ok(file) => {
                 assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt16);
-                assert_eq!(file.header().geometry(), "256:256:1");
+                assert_eq!(file.header().geometry().to_string(), "256:256:1");
                 assert_eq!(file.header().compression_codec(), "lz4");
             }
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,13 @@
     missing_debug_implementations,
     missing_copy_implementations
 )]
+#![allow(clippy::must_use_candidate)]
 
 mod convert;
 mod fitswriter;
 mod xisfreader;
 
-use crate::xisfreader::{XISFType, XISFile};
+use crate::xisfreader::{XISFData, XISFile};
 use log::info;
 use std::{
     io,
@@ -69,36 +70,41 @@ pub fn xisf_data_to_fits(xisf_file: &XISFile) -> (Box<[u8]>, i64) {
     // | Float32 | f32   | -32  |
     // | Float64 | f64   | -64  |
     // +---------+-------+------+
-    let header = xisf_file.header();
-    let data = xisf_file.data();
-
-    for i in 0..header.geometry_channels() as usize {
-        match header.sample_format() {
-            XISFType::UInt8 => {
-                bitpix = 8;
-                fits_data.extend_from_slice(&data.uint8[i]);
+    match xisf_file.data() {
+        XISFData::UInt8(ref data) => {
+            bitpix = 8;
+            for channel in data.iter() {
+                fits_data.extend_from_slice(channel);
             }
-            XISFType::UInt16 => {
-                bitpix = 16;
-                fits_data.append(&mut convert::u16_to_i16_to_v_u8_be(&data.uint16[i]));
-            }
-            XISFType::UInt32 => {
-                bitpix = 32;
-                fits_data.append(&mut convert::u32_to_i32_to_v_u8_be(&data.uint32[i]));
-            }
-            XISFType::Float32 => {
-                bitpix = -32;
-                fits_data.append(&mut convert::f32_to_v_u8_be(&data.float32[i]));
-            }
-            XISFType::Float64 => {
-                bitpix = -64;
-                fits_data.append(&mut convert::f64_to_v_u8_be(&data.float64[i]));
-            }
-            _ => println!(
-                "Convert to FITS > Unsupported XISF type > {}",
-                header.sample_format().as_str()
-            ),
         }
+        XISFData::UInt16(ref data) => {
+            bitpix = 16;
+            for channel in data.iter() {
+                fits_data.append(&mut convert::u16_to_i16_to_v_u8_be(channel));
+            }
+        }
+        XISFData::UInt32(ref data) => {
+            bitpix = 32;
+            for channel in data.iter() {
+                fits_data.append(&mut convert::u32_to_i32_to_v_u8_be(channel));
+            }
+        }
+        // XISFData::UInt64(ref data) => unimplemented!(),
+        XISFData::Float32(ref data) => {
+            bitpix = -32;
+            for channel in data.iter() {
+                fits_data.append(&mut convert::f32_to_v_u8_be(channel));
+            }
+        }
+        XISFData::Float64(ref data) => {
+            bitpix = -64;
+            for channel in data.iter() {
+                fits_data.append(&mut convert::f64_to_v_u8_be(channel));
+            }
+        }
+        // XISFData::Complex32(ref data) => unimplemented!(),
+        // XISFData::Complex64(ref data) => unimplemented!(),
+        XISFData::Empty => {}
     }
 
     // Show the first 20 bytes of the converted image
@@ -132,8 +138,8 @@ fn main() -> io::Result<()> {
         info!("Convert to FITS > Write image data");
         let fits_hd = fitswriter::FitsHeaderData {
             bitpix,
-            naxis: xisf_file.header().geometry_sizes().len() as u64,
-            naxis_vec: xisf_file.header().geometry_sizes(),
+            naxis: xisf_file.header().geometry().dimensions().len() as u64,
+            naxis_vec: xisf_file.header().geometry().dimensions(),
             bzero: 0,
             bscale: 1,
             datamin: 0,
@@ -171,7 +177,7 @@ mod test {
         let xisf_file = XISFile::read_file(xisf_filename);
         match xisf_file {
             Ok(file) => {
-                assert_eq!(file.header().sample_format(), XISFType::UInt8);
+                assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt8);
                 assert_eq!(file.header().geometry(), "256:256:1");
             }
             Err(e) => {
@@ -190,7 +196,7 @@ mod test {
         let xisf_file = XISFile::read_file(xisf_filename);
         match xisf_file {
             Ok(file) => {
-                assert_eq!(file.header().sample_format(), XISFType::UInt16);
+                assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt16);
                 assert_eq!(file.header().geometry(), "256:256:3");
             }
             Err(e) => {
@@ -209,7 +215,7 @@ mod test {
         let xisf_file = XISFile::read_file(xisf_filename);
         match xisf_file {
             Ok(file) => {
-                assert_eq!(file.header().sample_format(), XISFType::UInt32);
+                assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt32);
                 assert_eq!(file.header().geometry(), "256:256:3");
             }
             Err(e) => {
@@ -229,7 +235,7 @@ mod test {
 
         match xisf_file {
             Ok(file) => {
-                assert_eq!(file.header().sample_format(), XISFType::UInt8);
+                assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt8);
                 assert_eq!(file.header().geometry(), "256:256:3");
             }
             Err(e) => {
@@ -249,7 +255,7 @@ mod test {
 
         match xisf_file {
             Ok(file) => {
-                assert_eq!(file.header().sample_format(), XISFType::Float32);
+                assert_eq!(file.header().sample_format(), XISFSampleFormat::Float32);
                 assert_eq!(file.header().geometry(), "255:255:1");
             }
             Err(e) => {
@@ -269,7 +275,7 @@ mod test {
 
         match xisf_file {
             Ok(file) => {
-                assert_eq!(file.header().sample_format(), XISFType::Float64);
+                assert_eq!(file.header().sample_format(), XISFSampleFormat::Float64);
                 assert_eq!(file.header().geometry(), "255:255:1");
             }
             Err(e) => {
@@ -289,7 +295,7 @@ mod test {
 
         match xisf_file {
             Ok(file) => {
-                assert_eq!(file.header().sample_format(), XISFType::UInt16);
+                assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt16);
                 assert_eq!(file.header().geometry(), "256:256:1");
                 assert_eq!(file.header().compression_codec(), "zlib");
             }
@@ -310,7 +316,7 @@ mod test {
 
         match xisf_file {
             Ok(file) => {
-                assert_eq!(file.header().sample_format(), XISFType::UInt16);
+                assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt16);
                 assert_eq!(file.header().geometry(), "256:256:1");
                 assert_eq!(file.header().compression_codec(), "zlib+sh");
             }
@@ -332,7 +338,7 @@ mod test {
 
         match xisf_file {
             Ok(file) => {
-                assert_eq!(file.header().sample_format(), XISFType::UInt16);
+                assert_eq!(file.header().sample_format(), XISFSampleFormat::UInt16);
                 assert_eq!(file.header().geometry(), "256:256:1");
                 assert_eq!(file.header().compression_codec(), "lz4");
             }


### PR DESCRIPTION
This is a follow-up from #18, that goes even further with the optimizations.

This makes the `XISFData` type much smaller, and it won't grow adding more types. This will also conform better to the XISF specification:
 - https://pixinsight.com/doc/docs/XISF-1.0-spec/XISF-1.0-spec.html

I referenced the spec documentation directly in the code where needed. Especifically, this conforms 100% with n-dimensional images and with the allowed sample formats. Note that `UInt64`, `Complex32` and `Complex64` won't work yet.

I also added an extra optimization in the `u8_to_t!()` conversion macro, that will pre-allocate the whole buffer from the beginning, instead of growing it on each new value. This can be done because we know the size of things before the execution.

When generating the FITS data, we have some extra optimizations:
 - We don't re-compute the `bitpix` value on each iteration (this was probably being optimized away in the release mode, but now the debug version should be faster too)
 - We now use iterators in order to avoid bounds checking on each iteration step.

Then, the data generation has also been optimized by using `chunks_exact()`, that should yield all chunks with the same size. Nevertheless, there is currently no check to ensure this always happens. If it doesn't, the input image wouldn't be spec conformant, and therefore the behaviour is for now undefined.

Still a ton of `unwrap()` in the code, that can be solved in the future by using error propagation.